### PR TITLE
Reduce padding, adjust buttons, textarea background, h1 border

### DIFF
--- a/styles/colors.css
+++ b/styles/colors.css
@@ -8,9 +8,9 @@
     --select-background: #E0F2FE;         /* light sky blue */
     --select-text: #0F172A;               /* navy-like blue */
     --btn-bg-start: var(--select-background);
-    --btn-bg-end: #60A5FA;
+    --btn-bg-end: #78B0FD;
     --btn-text-color: var(--text-color);
-    --btn-shadow: #93C5FD;
+    --btn-shadow: #539CD8;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/styles/convert.css
+++ b/styles/convert.css
@@ -36,7 +36,7 @@ body {
   min-height: 8em;
   border: 1px solid var(--border-color);
   background-color: var(--text-background);
-  padding: .5em .5em .5em 1.5em;
+  padding: .5em .5em .5em 1em;
   overflow: auto;
   white-space: pre;
 }
@@ -81,6 +81,10 @@ body {
   min-width: 120px;
 }
 
+.select-group select {
+  margin-top: .2em;
+}
+
 .convert-button {
   margin-left: auto;
 }
@@ -121,7 +125,7 @@ body {
   width: 100%;
   background-color: var(--select-background);
   color: var(--select-text);
-  padding: 0.4em;
+  padding: 0.1em 0.4em 0.2em;
   border: 1px solid var(--border-color);
   border-radius: 4px;
   box-sizing: border-box;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,8 +5,8 @@ h1 {
   text-align: center;
   background: linear-gradient(to bottom, var(--h1-bg-start), var(--h1-bg-end));
   padding: 0.4em 1.2em;
-  border-top: 3px solid var(--h1-border-top);
-  border-bottom: 3px solid var(--h1-border-bottom);
+  border: 2px solid var(--h1-border-top);
+  border-bottom: 2.5px solid var(--h1-border-bottom);
   border-radius: 8px;
   color: var(--h1-text-color);
   text-shadow: 1px 1px 2px var(--h1-text-shadow);
@@ -31,7 +31,7 @@ input {
   background-color: var(--select-background);
   color: var(--select-text);
   border: 1px solid var(--border-color);
-  padding: 0.4em;
+  padding: 0.1em 0.4em 0.2em;
   font-size: 1em;
   border-radius: 4px;
   box-sizing: border-box;
@@ -42,21 +42,21 @@ input[type="radio"] {
 }
 
 input[type="button"] {
-  background: linear-gradient(to bottom, var(--btn-bg-start), var(--btn-bg-end));
+  background: radial-gradient(ellipse 250% 120% at 50% 30%, var(--btn-bg-start), var(--btn-bg-end));
   color: var(--btn-text-color);
-  padding: 0.5em 1.2em;
+  padding: 0.3em 1em;
   border: none;
   border-radius: 6px;
   font-weight: bold;
   font-size: 1em;
-  box-shadow: 0 4px var(--btn-shadow);
+  box-shadow: 1px 2.5px var(--btn-shadow);
   cursor: pointer;
-  transition: all 0.15s ease-in-out;
+  transition: all 0.075s ease-in-out;
 }
 
 input[type="button"]:active {
-  box-shadow: 0 2px var(--btn-shadow);
-  transform: translateY(2px); /* simulate press-down effect */
+  box-shadow: 0.75px 1px var(--btn-shadow);
+  transform: translateY(1.5px); /* simulate press-down effect */
 }
 
 /* Textarea */
@@ -67,9 +67,9 @@ input[type="button"]:active {
   padding: .3em;
   width: 100%;
   box-sizing: border-box;
-  background-color: var(--background-color);
+  background-color: var(--box-background);
   color: var(--text-color);
-  border: 1px solid var(--border-color);
+  border: 2px solid var(--border-color);
 }
 
 /* Output Display */
@@ -93,10 +93,12 @@ input[type="button"]:active {
 
 .left {
   float: left;
+  margin-top: 5px;
 }
 
 .right {
   float: right;
+  margin-top: 3px;
 }
 
 


### PR DESCRIPTION
This PR tweaks the CSS changes in the `refactor/speech-generator` branch.

It adjusts the button CSS, which seemed too dark to me.

I have never been a fan of the large padding on buttons and other input elements, so I've reduced the padding a bit for the buttons and drop-down menus.

I was not happy with the borders on the heading elements now that they have rounded corners and gradient coloring, so I added side borders as well.

Finally, the off-white background for the input text-area elements made them look disabled to me, so I changed them to white, but with a heavier border to help them stand out a bit.